### PR TITLE
Fix __cdecl redefined warning

### DIFF
--- a/miniutl.h
+++ b/miniutl.h
@@ -36,7 +36,9 @@
 		#define FMTFUNCTION( x, y )
 	#endif
 	#define _vsnprintf vsnprintf
+	#ifndef __cdecl
 	#define __cdecl
+	#endif
 #endif
 
 #if _MSC_VER >= 1600 && defined(_PREFAST_)// VS 2010 and above.


### PR DESCRIPTION
Compiling with MingW and linux emits this nasty warning quite many times. It also emits `warning: "FORCEINLINE" redefined`, but that'll stay unfixed for now.
