### PR TITLE
utlvector: fix compiler error

### DIFF
--- a/utlvector.h
+++ b/utlvector.h
@@ -137,7 +137,7 @@ public:
 	void SetGrowSize( int size )			{ m_Memory.SetGrowSize( size ); }
 
 	int NumAllocated() const { return m_Memory.NumAllocated(); }	// Only use this if you really know what you're doing!
-	
+
 	// Reverses the order of elements via swaps
 	void Reverse();
 
@@ -150,7 +150,7 @@ public:
 	int		SortedFindLessOrEqual( const T& search, bool (__cdecl *pfnLessFunc)( const T& src1, const T& src2, void *pCtx ), void *pLessContext ) const;
 	int		SortedFindLessOrEqual( const T& search, bool (__cdecl *pfnLessFunc)( const T& src1, const T& src2 ), int start, int end ) const;
 	int		SortedFindLessOrEqual( const T& search, bool (__cdecl *pfnLessFunc)( const T& src1, const T& src2 ) ) const;
-	
+
 	int		SortedInsert( const T& src, bool (__cdecl *pfnLessFunc)( const T& src1, const T& src2, void *pCtx ), void *pLessContext );
 	int		SortedInsert( const T& src, bool (__cdecl *pfnLessFunc)( const T& src1, const T& src2 ) );
 
@@ -596,7 +596,7 @@ inline int CUtlVector<T, A>::SortedInsert( const T& src, bool (__cdecl *pfnLessF
 template< typename T, class A >
 inline void CUtlVector<T, A>::Sort( int (__cdecl *pfnCompare)(const T *, const T *) )
 {
-	qsort( &Head(), Count(), sizeof( T ), (void*)pfnCompare );
+	qsort( &Head(), Count(), sizeof( T ), (int(*)(const void *, const void *))pfnCompare );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
```
../3rdparty/mainui/miniutl/utlvector.h: In instantiation of ‘void CUtlVector<T, A>::Sort(int (*)(const T*, const T*)) [with T = filterMap_t; A = CUtlMemory<filterMap_t>]’:
../3rdparty/mainui/menus/ServerBrowser.cpp:548:19:   required from here
../3rdparty/mainui/miniutl/utlvector.h:599:47: error: invalid conversion from ‘void*’ to ‘__compar_fn_t’ {aka ‘int (*)(const void*, const void*)’} [-fpermissive]
  599 |         qsort( &Head(), Count(), sizeof( T ), (void*)pfnCompare );
      |                                               ^~~~~~~~~~~~~~~~~
      |                                               |
      |                                               void*
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/cstdlib:79,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/stdlib.h:36,
                 from ../3rdparty/mainui/extdll_menu.h:49,
                 from ../3rdparty/mainui/enginecallback_menu.h:22,
                 from ../3rdparty/mainui/BaseMenu.h:21:
/usr/include/stdlib.h:852:34: note:   initializing argument 4 of ‘void qsort(void*, size_t, size_t, __compar_fn_t)’
  852 |                    __compar_fn_t __compar) __nonnull ((1, 4));
      |                    ~~~~~~~~~~~~~~^~~~~~~~
```