### PR TITLE
miniutl IRIX patches

### DIFF
--- a/fmtstr.h
+++ b/fmtstr.h
@@ -25,6 +25,14 @@
 #pragma GCC visibility push(hidden)
 #endif
 
+#if defined(IRIX_GCC_SIGNBIT_COMPAT)
+// compatibility for signbit on IRIX when using GCC
+#undef signbit
+#define signbit(x) (sizeof(x) == sizeof(double) ? _signbit(x) \
+	: sizeof(x) == sizeof(float) ? _signbitf(x) \
+	: _signbitl(x))
+#endif
+
 //=============================================================================
 
 // using macro to be compatible with GCC

--- a/generichash.cpp
+++ b/generichash.cpp
@@ -50,7 +50,9 @@ uint32_t MurmurHash3_32( const void * key, size_t len, uint32_t seed, bool bCase
 
 	for(ptrdiff_t i = -nblocks; i; i++)
 	{
-		uint32_t k1 = LittleDWord(blocks[i]);
+		uint32_t t1;
+		memcpy(&t1, blocks+i, sizeof(uint32_t));
+		uint32_t k1 = LittleDWord(t1);
 		k1 &= uSourceBitwiseAndMask;
 
 		k1 *= 0xcc9e2d51;

--- a/utlstring.cpp
+++ b/utlstring.cpp
@@ -11,6 +11,31 @@
 #include "utlvector.h"
 #include "winlite.h"
 
+#ifndef HAVE_VASPRINTF
+int vasprintf ( char **strp, const char *fmt, va_list ap)
+{
+	int len, str_len;
+	len = vsnprintf( NULL, 0, fmt, ap );
+
+	if ( ( len >= 0 ) && ( len < INT_MAX ) )
+	{
+		*strp = (char*) malloc ( len + 1 );
+		if ( strp != NULL )
+		{
+			str_len = vsnprintf( *strp, len + 1, fmt, ap);
+			if ( str_len >= 0 )
+			{
+				return str_len;
+			}
+		}
+	}
+
+	// Error condition
+	*strp = NULL;
+	return -1;
+}
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: Helper: Find s substring
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Additional patches that are needed for xash to build on IRIX. 

The macros in this are dependent on the wscript configuration in https://github.com/FWGS/mainui_cpp/pull/135 as miniutl doesn't have its own wscript configuration and gets built using the wscript in mainui